### PR TITLE
add pytest-timeout, default to 10s

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,7 @@ envlist = py27, py33, py34, py35
 commands = py.test {posargs:tests/}
 deps =
     pytest
+    pytest-timeout
+
+[pytest]
+timeout = 10


### PR DESCRIPTION
Add pytest-timeout to fail tests that take longer than 10 seconds.
