### PR TITLE
add tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.5"
 # install dependencies
 install:
-    - pip install pytest
-    - pip install tox
+    - pip install tox tox-travis
 # run tests
 script: tox


### PR DESCRIPTION
to run the correct py version for each travis env
